### PR TITLE
feat: add config and unconfig run scripts

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,10 @@
     "start": "electron .",
     "pack": "electron-builder --dir",
     "dist": "electron-builder",
-    "postinstall": "electron-builder install-app-deps"
+    "postinstall": "electron-builder install-app-deps",
+    "ipfs": "ipfs daemon --enable-pubsub-experiment",
+    "config": "npm config set proxy=http://0.0.0.0:8005/ https-proxy=http://0.0.0.0:8005/ registry=http://registry.npmjs.org/ strict-ssl=false",
+    "unconfig": "npm config delete proxy https-proxy registry strict-ssl"
   },
   "dependencies": {
     "changes-stream": "^2.2.0",

--- a/readme.md
+++ b/readme.md
@@ -45,15 +45,24 @@ npm install
 Configure npm to use forest as a proxy:
 
 ```shell
+npm run config
+
+# or manually set the following in your .npmrc
 npm config set proxy http://0.0.0.0:8005/
 npm config set https-proxy http://0.0.0.0:8005/
 npm config set registry http://registry.npmjs.org/
 npm config set strict-ssl false
+
+# restore the defaults with
+npm run unconfig
 ```
 
 Ensure IPFS is running locally with pubsub enabled:
 
 ```shell
+npm run ipfs
+
+# or 
 ipfs daemon --enable-pubsub-experiment
 ```
 


### PR DESCRIPTION
I try to update the forest deps without forest running. It no work.

- Add `npm run config` to quick add forest proxy config to npmrc
- Add `npm run unconfig` to restore defaults
- Add `npm run ipfs` because i was there and i forget the pubsub flag