### PR TITLE
fix: git URL

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -48,7 +48,7 @@ Javascript API - integrate forest into other javascript applications
 Build from source on mac:
 
 ```shell
-git clone http://github.com/forestpm/forest
+git clone https://github.com/forestpm/forest.git
 cd forest
 npm install
 ```


### PR DESCRIPTION
I was getting the following message when pulling:

```console
➜ git pull
warning: redirecting to https://github.com/forestpm/forest/
```